### PR TITLE
No AVX workaround (until official fix)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -34,7 +34,7 @@ echo " "
 echo "steam_appid: "`cat $s/steam_appid.txt`
 
 echo " "
-if [ ! grep -q -E '^flags.*\b(avx|avx2)\b' /proc/cpuinfo ]; then
+if ! grep -o 'avx[^ ]*' /proc/cpuinfo; then
 	unsupported_file="VRisingServer_Data/Plugins/x86_64/lib_burst_generated.dll"
 	echo "AVX or AVX2 not supported; Check if unsupported ${unsupported_file} exists"
 	if [ -f "${path_server}/${unsupported_file}" ]; then

--- a/start.sh
+++ b/start.sh
@@ -30,8 +30,19 @@ chmod -R 777 /root/.steam 2>/dev/null
 echo " "
 echo "Updating V-Rising Dedicated Server files..."
 echo " "
-/usr/bin/steamcmd +force_install_dir "$s" +login anonymous +app_update 1829350 +quit
+/usr/bin/steamcmd +force_install_dir "$s" +login anonymous +app_update 1829350 validate +quit
 echo "steam_appid: "`cat $s/steam_appid.txt`
+
+echo " "
+if [ ! grep -q -E '^flags.*\b(avx|avx2)\b' /proc/cpuinfo ]; then
+	unsupported_file="VRisingServer_Data/Plugins/x86_64/lib_burst_generated.dll"
+	echo "AVX or AVX2 not supported; Check if unsupported ${unsupported_file} exists"
+	if [ -f "${path_server}/${unsupported_file}" ]; then
+		echo "Changing ${unsupported_file} as attempt to fix issues..."
+		mv "${path_server}/${unsupported_file}" "${path_server}/${unsupported_file}.bak"
+	fi
+fi
+
 echo " "
 mkdir "$p/Settings" 2>/dev/null
 if [ ! -f "$p/Settings/ServerGameSettings.json" ]; then


### PR DESCRIPTION
In a recent hotfix, the VRisingServer requires AVX support (according to the Discord) and older (or virtualized) CPUs do not support this, resulting in an error regarding the file `VRisingServer_Data\Plugins\x86_64\lib_burst_generated.dll`. This modification adds a check to see if the CPU supports it, and if not, renames the offending file to file.bak. 