### PR TITLE
Fix gracefully shutdown and add container wide log files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update -y && \
     dpkg --add-architecture i386 && \
     apt update -y && \
     apt-get upgrade -y 
+    
 RUN useradd -m steam && cd /home/steam && \
     echo steam steam/question select "I AGREE" | debconf-set-selections && \
     echo steam steam/license note '' | debconf-set-selections && \
@@ -22,6 +23,7 @@ RUN useradd -m steam && cd /home/steam && \
     apt install -y steam \
                    steamcmd && \
     ln -s /usr/games/steamcmd /usr/bin/steamcmd
+
 #RUN apt install -y mono-complete
 RUN apt install -y wine \
                    winbind
@@ -31,6 +33,17 @@ RUN rm -rf /var/lib/apt/lists/* && \
     apt clean && \
     apt autoremove -y
 
-COPY start.sh /start.sh
-RUN chmod +x /start.sh
-CMD ["/start.sh"]
+ENV STEAMAPP vrising
+ENV STEAMAPPDIR "/mnt/${STEAMAPP}"
+ENV STEAMAPPSERVER "${STEAMAPPDIR}/server"
+ENV STEAMAPPDATA "${STEAMAPPDIR}/persistentdata"
+ENV LOGSDIR "${STEAMAPPDATA}/logs"
+ENV SCRIPTSDIR "${STEAMAPPDIR}/scripts"
+
+RUN mkdir ${STEAMAPPDIR} ${STEAMAPPSERVER} ${STEAMAPPDATA} ${SCRIPTSDIR}
+
+COPY ./scripts ${SCRIPTSDIR}
+
+RUN chmod +x ${SCRIPTSDIR}/*.sh
+
+CMD ["/mnt/vrising/scripts/init.sh"]

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ ! -d "$LOGSDIR" ]; then mkdir "$LOGSDIR"; fi
+
+# Rename latest.log to VRising-{LastModifiedDate}.log
+# if the file exists and its not empty
+ContainerLog="$LOGSDIR/latest.log"
+if [ -f "$ContainerLog" ] && [ -s "$ContainerLog" ]; then
+	LogDate=$(date --date="@$(stat -c "%Y" "$ContainerLog")" +'%Y%m%d-%H%M%S')
+    mv "$ContainerLog" "$LOGSDIR/VRising-$LogDate.log"
+fi
+
+term_handler() {
+    # First we get the hexdec value of the Win PID 
+    WinHexPID=$(winedbg --command "info proc" | grep -Po '^\s*\K.{8}(?=.*VRisingServer\.exe)')
+
+    # Now we convert the hexdec to decimal 
+    # and use it to send an taskkill via CMD
+    wine cmd.exe /C "taskkill /pid $(( 0x$WinHexPID ))"
+
+    # Wineserver should exit after the gameserver is shutdown,
+    # so we wait for it
+    wineserver -w
+
+    exit
+    # Yeepii, we gracefully shutdown the gameserver! \'-'/
+}
+
+# Trap SIGTERM so we can gracefully shutdown the gameserver
+trap 'term_handler' SIGTERM
+
+# Not using pipes so we can capture bash PID later
+/bin/bash "$SCRIPTSDIR/start.sh" > >(tee "$ContainerLog") 2>&1 &
+
+# PID of bash
+killpid=$!
+wait "$killpid"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+SERVERNAME=${SERVERNAME:-"trueosiris-V"}
+WORLDNAME=${WORLDNAME:-"world1"}
+
+game_port=""
+if [ -n "$GAMEPORT" ]; then
+	game_port=" -gamePort $GAMEPORT"
+fi
+query_port=""
+if [ -n "$QUERYPORT" ]; then
+	query_port=" -queryPort $QUERYPORT"
+fi
+
+mkdir -p /root/.steam 2>/dev/null
+chmod -R 777 /root/.steam 2>/dev/null
+
+echo " "
+echo "Updating V-Rising Dedicated Server files..."
+echo " "
+
+/usr/bin/steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "${STEAMAPPSERVER}" +login anonymous +app_update 1829350 validate +quit
+echo "steam_appid: $(cat "${STEAMAPPSERVER}"/steam_appid.txt)"
+
+if ! grep -q -o 'avx[^ ]*' /proc/cpuinfo; then
+	echo " "
+	unsupported_file="VRisingServer_Data/Plugins/x86_64/lib_burst_generated.dll"
+	echo "AVX or AVX2 not supported; Check if unsupported ${unsupported_file} exists"
+	if [ -f "${STEAMAPPSERVER}/${unsupported_file}" ]; then
+		echo "Changing ${unsupported_file} as attempt to fix issues..."
+		mv "${STEAMAPPSERVER}/${unsupported_file}" "${STEAMAPPSERVER}/${unsupported_file}.bak"
+	fi
+fi
+
+if [ ! -d "$LOGSDIR" ]; then mkdir "${STEAMAPPDATA}/Settings"; fi
+
+if [ ! -f "${STEAMAPPDATA}/Settings/ServerGameSettings.json" ]; then
+		echo " "
+        echo "${STEAMAPPDATA}/Settings/ServerGameSettings.json not found. Copying default file."
+        cp "${STEAMAPPSERVER}/VRisingServer_Data/StreamingAssets/Settings/ServerGameSettings.json" "${STEAMAPPDATA}/Settings/"
+fi
+if [ ! -f "${STEAMAPPDATA}/Settings/ServerHostSettings.json" ]; then
+		echo " "
+        echo "${STEAMAPPDATA}/Settings/ServerHostSettings.json not found. Copying default file."
+        cp "${STEAMAPPSERVER}/VRisingServer_Data/StreamingAssets/Settings/ServerHostSettings.json" "${STEAMAPPDATA}/Settings/"
+fi
+
+#Restart cleanup
+if [ -f "/tmp/.X0-lock" ]; then 
+	echo "Removing /tmp/.X0-lock"
+	rm /tmp/.X0-lock 
+fi
+
+cd "${STEAMAPPSERVER}" || exit
+
+echo "Starting V Rising Dedicated Server with name $SERVERNAME"
+echo " "
+
+echo "Starting Xvfb"
+Xvfb :0 -screen 0 1024x768x16 &
+
+echo "Launching wine64 V Rising"
+echo " "
+
+# If we dont supply an file for it to log into,
+# it will log into console, which is better for us
+DISPLAY=:0.0 wine64 "${STEAMAPPSERVER}"/VRisingServer.exe \
+	-persistentDataPath "${STEAMAPPDATA}" \
+	-serverName "$SERVERNAME" \
+	-saveName "$WORLDNAME" "$game_port" "$query_port"


### PR DESCRIPTION
Refactor was needed in order to capture the entire container log (including things like steamcmd) reliably.

The gracefully shutdown i had written previously wasnt actually waiting for the gameserver to shutdown, i tried with `kill -SIGINT` on multiple processes, tried using `wineserver -k` but none of those actually were properly shutting it down, so i came up with the solution of shutting it down on an more windows way.