### PR TITLE
Add winetricks to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN useradd -m steam && cd /home/steam && \
     ln -s /usr/games/steamcmd /usr/bin/steamcmd
 #RUN apt install -y mono-complete
 RUN apt install -y wine \
-                   winbind
+                   winbind \
+                   winetricks
 RUN apt install -y xserver-xorg \
                    xvfb
 RUN rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
My Debian vm was throwing the following error 
```
010c:fixme:winsock:WSAIoctl unsupported WS_IOCTL cmd (SIO_IDEAL_SEND_BACKLOG_QUERY)

```

Adding winetricks to the image has resolved a number of flags.
I am still getting the winsock error from #47 but the server will eventually work through it and start, then after data is created I haven't seen the error again. 

We should do more investigation on this, but this worked for me. 