### PR TITLE
Add log Deletion based on numbr of days old

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/
 server/
 
+/.vs

--- a/start.sh
+++ b/start.sh
@@ -13,8 +13,16 @@ term_handler() {
     exit
 }
 
+cleanup_logs() {
+    echo "Cleaning up logs older than $LOGDAYS days"
+    find "$p" -name "*.log" -type f -mtime +$LOGDAYS -exec rm {} \;
+}
+
 trap 'term_handler' SIGTERM
 
+if [ -z "$LOGDAYS" ]; then
+    LOGDAYS=3
+fi
 if [ ! -z $UID ]; then
 	usermod -u $UID docker 2>&1
 fi 
@@ -36,6 +44,9 @@ query_port=""
 if [ ! -z $QUERYPORT ]; then
 	query_port=" -queryPort $QUERYPORT"
 fi
+
+cleanup_logs
+
 mkdir -p /root/.steam 2>/dev/null
 chmod -R 777 /root/.steam 2>/dev/null
 echo " "


### PR DESCRIPTION
Completes #63 

Add LOGDAYS env var allowing users to set number of days to say log

I figured setting a number of days was a bit more flexible in case the server was in some sort of loop, you don't lose history.

This will remove all logs older than 3 days by default when not env var is present 