### PR TITLE
Initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | GAMEPORT   | optional game udp port | to overrule Port in ServerHostSettings.json config                                |
 | QUERYPORT  | optional query port    | to overrule QueryPort in ServerHostSettings.json config                           |
 | LOGDAYS | optional lifetime of logfiles | overrule default of 30 days |
+| BRANCH | Select the server version | Allows to run the server version legacy-1.0.x-pc |
 
 ## Ports
 

--- a/start.sh
+++ b/start.sh
@@ -49,6 +49,10 @@ if [[ -n $QUERYPORT ]]; then
 	query_port=" -queryPort $QUERYPORT"
 fi
 
+beta_arg=""
+if [ -n "$BRANCH" ]; then
+  beta_arg=" -beta $BRANCH" 
+fi
 cleanup_logs
 
 mkdir -p /root/.steam 2>/dev/null
@@ -56,7 +60,7 @@ chmod -R 777 /root/.steam 2>/dev/null
 echo " "
 echo "Updating V-Rising Dedicated Server files..."
 echo " "
-/usr/bin/steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "$s" +login anonymous +app_update 1829350 validate +quit
+/usr/bin/steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir "$s" +login anonymous +app_update 1829350 $beta_arg validate +quit
 printf "steam_appid: "
 cat "$s/steam_appid.txt"
 


### PR DESCRIPTION
**What’s new**
You can now pick a legacy server build by setting a BRANCH env var. If BRANCH is defined, we add -beta $BRANCH to the steamcmd update command so you get exactly that version.

**How it works**
- If you run:
`export BRANCH=legacy-1.0.x-pc
`

the updater will do:
`steamcmd +login anonymous \
         +force_install_dir ./server \
         +login anonymous \
         +app_update 1829350 \
         -beta legacy-1.0.x-pc \
         validate \
         +quit
`
which installs the old v3 server.

If BRANCH isn’t set, everything runs exactly like before.