### PR TITLE
Add dynamic parameter setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt install -y wine \
                    winetricks
 RUN apt install -y xserver-xorg \
                    xvfb
+RUN apt update -y && apt install -y jq
 RUN rm -rf /var/lib/apt/lists/* && \
     apt clean && \
     apt autoremove -y

--- a/start.sh
+++ b/start.sh
@@ -74,6 +74,140 @@ if ! grep -q -o 'avx[^ ]*' /proc/cpuinfo; then
 	fi
 fi
 
+# Function to update JSON settings using jq
+update_json_settings() {
+    local json_file="$1"
+    local prefix="$2"
+    local tmp_file="${json_file}.tmp"
+
+    if ! command -v jq &> /dev/null; then
+        echo "jq not found, cannot update JSON."
+        return 1
+    fi
+
+    cp "$json_file" "$tmp_file"
+
+    # Get all environment variables with the given prefix
+    mapfile -t env_vars < <(env | grep -E "^${prefix}[^=]+" | cut -d= -f1)
+
+    for var in "${env_vars[@]}"; do
+        local raw_value="${!var}"
+        # Remove the prefix and convert to lowercase for matching
+        local stripped_name="${var#${prefix}}"
+        # Convert to lowercase and replace underscores with dots for nested paths
+        local search_key=$(echo "$stripped_name" | tr '[:upper:]' '[:lower:]' | sed 's/__/./g')
+
+        # Find the key path with case-insensitive matching and get the original value type
+        local key_info
+        key_info=$(jq -r --arg key "$search_key" '
+            def find_path($obj; $key_parts; $current_path; $current_type):
+                if ($key_parts | length) == 0 then
+                    {path: $current_path, type: $current_type}
+                else
+                    $obj | to_entries | .[] |
+                    select(.key | ascii_downcase == $key_parts[0]) |
+                    find_path(.value; $key_parts[1:];
+                             $current_path + [.key];
+                             .value | type) // empty
+                end;
+
+            ($key | split(".")) as $key_parts |
+            find_path(.; $key_parts; []; null) |
+            "\(.path | join(".")),\(.type)"
+        ' "$tmp_file" 2>/dev/null)
+
+        if [ -n "$key_info" ]; then
+            IFS=',' read -r matched_path value_type <<< "$key_info"
+            local jq_path=""
+            IFS='.' read -ra parts <<< "$matched_path"
+            for part in "${parts[@]}"; do
+                jq_path+=".\"$part\""
+            done
+
+            local jq_set
+            case "$value_type" in
+                "string")
+                    jq_set="$jq_path = \"${raw_value//\"/\\\"}\""
+                    ;;
+                "boolean")
+                    # Convert to lowercase for case-insensitive comparison
+                    local lower_value=$(echo "$raw_value" | tr '[:upper:]' '[:lower:]')
+                    if [[ ! "$lower_value" =~ ^(true|false)$ ]]; then
+                        echo "Error: '$matched_path' must be a boolean (true/false), skipping..."
+                        continue
+                    fi
+                    # Always use lowercase true/false in the output
+                    jq_set="$jq_path = $lower_value"
+                    ;;
+                "number"|"integer")
+                    if [[ ! "$raw_value" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+                        echo "Error: '$matched_path' must be a number, skipping..."
+                        continue
+                    fi
+                    jq_set="$jq_path = $raw_value"
+                    ;;
+                "array")
+                    # Special handling for array types - try to parse as JSON array
+                    if [[ "$raw_value" =~ ^\[.*\]$ ]]; then
+                        # If it looks like a JSON array, try to parse it
+                        if jq -e . <<< "$raw_value" >/dev/null 2>&1; then
+                            jq_set="$jq_path = $raw_value"
+                        else
+                            echo "Error: Invalid JSON array format for '$matched_path', skipping..."
+                            continue
+                        fi
+                    else
+                        # If it's not a JSON array, treat as a single value array
+                        jq_set="$jq_path = [\"$raw_value\"]"
+                    fi
+                    ;;
+                *)
+                    # For unknown types, try to preserve the original type
+                    if [[ "$raw_value" =~ ^(true|false)$ ]]; then
+                        jq_set="$jq_path = $raw_value"
+                    elif [[ "$raw_value" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+                        jq_set="$jq_path = $raw_value"
+                    else
+                        jq_set="$jq_path = \"${raw_value//\"/\\\"}\""
+                    fi
+                    ;;
+            esac
+
+            if jq -e "$jq_set" "$tmp_file" > "${tmp_file}.new" 2>/dev/null; then
+                mv "${tmp_file}.new" "$tmp_file"
+            else
+                echo "Failed to update: $matched_path"
+                echo "   jq command: jq '$jq_set' $tmp_file"
+            fi
+        else
+            # Try to find the key with exact case for better error message
+            local exact_key=$(echo "$stripped_name" | tr '_' '.')
+            local key_exists=false
+
+            # Check if the key exists in the JSON (case insensitive)
+            if jq -e --arg key "$exact_key" '
+                def key_exists($obj; $key_parts):
+                    if ($key_parts | length) == 0 then
+                        true
+                    else
+                        $obj | to_entries | any(
+                            .key | ascii_downcase == $key_parts[0]
+                            and key_exists(.value; $key_parts[1:])
+                        )
+                    end;
+                key_exists(.; $key | split("."))
+            ' "$tmp_file" >/dev/null 2>&1; then
+                echo "Found key but couldn't update (possible type mismatch): $stripped_name"
+            else
+                echo "Ignoring non-existent setting: $stripped_name"
+            fi
+        fi
+    done
+
+    mv "$tmp_file" "$json_file"
+    echo "Finished updating $json_file"
+}
+
 echo " "
 mkdir "$p/Settings" 2>/dev/null
 if [ ! -f "$p/Settings/ServerGameSettings.json" ]; then
@@ -83,6 +217,17 @@ fi
 if [ ! -f "$p/Settings/ServerHostSettings.json" ]; then
 	echo "$p/Settings/ServerHostSettings.json not found. Copying default file."
 	cp "$s/VRisingServer_Data/StreamingAssets/Settings/ServerHostSettings.json" "$p/Settings/" 2>&1
+fi
+
+# Update settings from environment variables
+if [ $(env | grep -c '^GAME_SETTINGS_') -gt 0 ]; then
+  echo "Updating game settings from environment variables..."
+  update_json_settings "$p/Settings/ServerGameSettings.json" "GAME_SETTINGS_"
+fi
+
+if [ $(env | grep -c '^HOST_SETTINGS_') -gt 0 ]; then
+  echo "Updating host settings from environment variables..."
+  update_json_settings "$p/Settings/ServerHostSettings.json" "HOST_SETTINGS_"
 fi
 
 # Checks if log file exists, if not creates it


### PR DESCRIPTION
- **Compatibility** — does not affect existing users or server.
- **Simple use** — can be started with just the docker-compose.yml file.
- **Intuitive parameters** — If you want to modify parameters in `ServerGameSettings.json` and `ServerHostSettings.json`, add environment variables starting with `GAME_SETTINGS_` and `HOST_SETTINGS_` (both must be uppercase) in your docker-compose.yml file. The parameter names that follow are case-insensitive, so `HOST_SETTINGS_LISTONSTEAM` and `HOST_SETTINGS_ListOnSteam` both work.
```yaml
environment:
  - HOST_SETTINGS_ListOnSteam=true
  - HOST_SETTINGS_LISTONEOS=true
  - GAME_SETTINGS_GAMEMODETYPE=PvE
```
- **Supports dynamic modification of nested JSON parameters** — since some parameter names contain `_`, a double underscore `__` is used to separate levels.
```yaml
environment:
  - HOST_SETTINGS_Rcon__Enabled=true
  - HOST_SETTINGS_Rcon__Password=powerfulpwd
  - GAME_SETTINGS_UnitStatModifiers_Global__MaxHealthModifier=2
  - GAME_SETTINGS_CastleStatModifiers_Global__HeartLimits__Level1__FloorLimit=100
```
- **Fail-safe** — entering a non-existent parameter like `HOST_SETTINGS_NotExistKey=1` will not be written to the configuration file.
- **Parameter type validation** — if the input type differs from the original like `HOST_SETTINGS_Port=abcd`, it will not be written to the configuration file.
- All modified parameter settings can be viewed in:
  - `/mnt/vrising/persistentdata/Settings/ServerGameSettings.json`
  - `/mnt/vrising/persistentdata/Settings/ServerHostSettings.json`